### PR TITLE
Make tests pass

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,8 +6,7 @@
         "ng": "ng",
         "start": "ng serve",
         "build": "ng build --prod",
-        "gitbuild":
-            "ng build --prod --base-href /start-angular/SB-Admin-BS4-Angular-6/master/dist/",
+        "gitbuild": "ng build --prod --base-href /start-angular/SB-Admin-BS4-Angular-6/master/dist/",
         "test": "ng test",
         "lint": "ng lint",
         "e2e": "ng e2e"

--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -1,26 +1,31 @@
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { async, ComponentFixture, TestBed } from '@angular/core/testing'
+import { APP_BASE_HREF } from '@angular/common'
 
-import { AppComponent } from './app.component';
+import { AppComponent } from './app.component'
+import { AppModule } from './app.module'
 
 describe('AppComponent', () => {
-    let component: AppComponent;
-    let fixture: ComponentFixture<AppComponent>;
+  let component: AppComponent
+  let fixture: ComponentFixture<AppComponent>
 
-    beforeEach(
-        async(() => {
-            TestBed.configureTestingModule({
-                declarations: [AppComponent]
-            }).compileComponents();
-        })
-    );
+  beforeEach(
+    async(() => {
+      TestBed.configureTestingModule({
+        imports: [AppModule],
+        providers: [
+          { provide: APP_BASE_HREF, useValue: '/' },
+        ]
+      }).compileComponents()
+    })
+  )
 
-    beforeEach(() => {
-        fixture = TestBed.createComponent(AppComponent);
-        component = fixture.componentInstance;
-        fixture.detectChanges();
-    });
+  beforeEach(() => {
+    fixture = TestBed.createComponent(AppComponent)
+    component = fixture.componentInstance
+    fixture.detectChanges()
+  })
 
-    it('should create', () => {
-        expect(component).toBeTruthy();
-    });
-});
+  it('should create', () => {
+    expect(component).toBeTruthy()
+  })
+})

--- a/src/app/layout/bs-component/bs-component.component.spec.ts
+++ b/src/app/layout/bs-component/bs-component.component.spec.ts
@@ -1,26 +1,28 @@
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { async, ComponentFixture, TestBed } from '@angular/core/testing'
+import { RouterTestingModule } from '@angular/router/testing'
 
-import { BsComponentComponent } from './bs-component.component';
+import { BsComponentComponent } from './bs-component.component'
+import { BsComponentModule } from './bs-component.module'
 
 describe('BsComponentComponent', () => {
-    let component: BsComponentComponent;
-    let fixture: ComponentFixture<BsComponentComponent>;
+  let component: BsComponentComponent
+  let fixture: ComponentFixture<BsComponentComponent>
 
-    beforeEach(
-        async(() => {
-            TestBed.configureTestingModule({
-                declarations: [BsComponentComponent]
-            }).compileComponents();
-        })
-    );
+  beforeEach(
+    async(() => {
+      TestBed.configureTestingModule({
+        imports: [BsComponentModule, RouterTestingModule],
+      }).compileComponents()
+    })
+  )
 
-    beforeEach(() => {
-        fixture = TestBed.createComponent(BsComponentComponent);
-        component = fixture.componentInstance;
-        fixture.detectChanges();
-    });
+  beforeEach(() => {
+    fixture = TestBed.createComponent(BsComponentComponent)
+    component = fixture.componentInstance
+    fixture.detectChanges()
+  })
 
-    it('should create', () => {
-        expect(component).toBeTruthy();
-    });
-});
+  it('should create', () => {
+    expect(component).toBeTruthy()
+  })
+})

--- a/src/app/layout/bs-component/components/rating/rating.component.spec.ts
+++ b/src/app/layout/bs-component/components/rating/rating.component.spec.ts
@@ -1,25 +1,28 @@
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { async, ComponentFixture, TestBed } from '@angular/core/testing'
+import { RouterTestingModule } from '@angular/router/testing'
 
-import { RatingComponent } from './rating.component';
+import { RatingComponent } from './rating.component'
+import { BsComponentModule } from '../../bs-component.module'
 
 describe('RatingComponent', () => {
-  let component: RatingComponent;
-  let fixture: ComponentFixture<RatingComponent>;
+  let component: RatingComponent
+  let fixture: ComponentFixture<RatingComponent>
 
-  beforeEach(async(() => {
-    TestBed.configureTestingModule({
-      declarations: [ RatingComponent ]
+  beforeEach(
+    async(() => {
+      TestBed.configureTestingModule({
+        imports: [BsComponentModule, RouterTestingModule],
+      }).compileComponents()
     })
-    .compileComponents();
-  }));
+  )
 
   beforeEach(() => {
-    fixture = TestBed.createComponent(RatingComponent);
-    component = fixture.componentInstance;
-    fixture.detectChanges();
-  });
+    fixture = TestBed.createComponent(RatingComponent)
+    component = fixture.componentInstance
+    fixture.detectChanges()
+  })
 
   it('should create', () => {
-    expect(component).toBeTruthy();
-  });
-});
+    expect(component).toBeTruthy()
+  })
+})

--- a/src/app/layout/bs-component/components/tooltip/tooltip.component.spec.ts
+++ b/src/app/layout/bs-component/components/tooltip/tooltip.component.spec.ts
@@ -1,25 +1,27 @@
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { async, ComponentFixture, TestBed } from '@angular/core/testing'
+import { RouterTestingModule } from '@angular/router/testing'
 
-import { TooltipComponent } from './tooltip.component';
+import { TooltipComponent } from './tooltip.component'
+import { BsComponentModule } from '../../bs-component.module'
 
 describe('TooltipComponent', () => {
-  let component: TooltipComponent;
-  let fixture: ComponentFixture<TooltipComponent>;
+  let component: TooltipComponent
+  let fixture: ComponentFixture<TooltipComponent>
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      declarations: [ TooltipComponent ]
+      imports: [BsComponentModule, RouterTestingModule]
     })
-    .compileComponents();
-  }));
+    .compileComponents()
+  }))
 
   beforeEach(() => {
-    fixture = TestBed.createComponent(TooltipComponent);
-    component = fixture.componentInstance;
-    fixture.detectChanges();
-  });
+    fixture = TestBed.createComponent(TooltipComponent)
+    component = fixture.componentInstance
+    fixture.detectChanges()
+  })
 
   it('should create', () => {
-    expect(component).toBeTruthy();
-  });
-});
+    expect(component).toBeTruthy()
+  })
+})

--- a/src/app/layout/bs-element/bs-element.component.spec.ts
+++ b/src/app/layout/bs-element/bs-element.component.spec.ts
@@ -1,25 +1,28 @@
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { async, ComponentFixture, TestBed } from '@angular/core/testing'
+import { RouterTestingModule } from '@angular/router/testing'
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations'
 
-import { BsElementComponent } from './bs-element.component';
+import { BsElementComponent } from './bs-element.component'
+import { BsElementModule } from './bs-element.module'
 
 describe('BsElementComponent', () => {
-  let component: BsElementComponent;
-  let fixture: ComponentFixture<BsElementComponent>;
+  let component: BsElementComponent
+  let fixture: ComponentFixture<BsElementComponent>
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      declarations: [ BsElementComponent ]
+      imports: [BsElementModule, RouterTestingModule, BrowserAnimationsModule]
     })
-    .compileComponents();
-  }));
+    .compileComponents()
+  }))
 
   beforeEach(() => {
-    fixture = TestBed.createComponent(BsElementComponent);
-    component = fixture.componentInstance;
-    fixture.detectChanges();
-  });
+    fixture = TestBed.createComponent(BsElementComponent)
+    component = fixture.componentInstance
+    fixture.detectChanges()
+  })
 
   it('should create', () => {
-    expect(component).toBeTruthy();
-  });
-});
+    expect(component).toBeTruthy()
+  })
+})

--- a/src/app/layout/charts/charts.component.spec.ts
+++ b/src/app/layout/charts/charts.component.spec.ts
@@ -1,26 +1,33 @@
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { async, ComponentFixture, TestBed } from '@angular/core/testing'
+import { RouterTestingModule } from '@angular/router/testing'
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations'
 
-import { ChartsComponent } from './charts.component';
+import { ChartsComponent } from './charts.component'
+import { ChartsModule } from './charts.module'
 
 describe('ChartsComponent', () => {
-    let component: ChartsComponent;
-    let fixture: ComponentFixture<ChartsComponent>;
+  let component: ChartsComponent
+  let fixture: ComponentFixture<ChartsComponent>
 
-    beforeEach(
-        async(() => {
-            TestBed.configureTestingModule({
-                declarations: [ChartsComponent]
-            }).compileComponents();
-        })
-    );
+  beforeEach(
+    async(() => {
+      TestBed.configureTestingModule({
+        imports: [
+          ChartsModule,
+          RouterTestingModule,
+          BrowserAnimationsModule,
+        ],
+      }).compileComponents()
+    })
+  )
 
-    beforeEach(() => {
-        fixture = TestBed.createComponent(ChartsComponent);
-        component = fixture.componentInstance;
-        fixture.detectChanges();
-    });
+  beforeEach(() => {
+    fixture = TestBed.createComponent(ChartsComponent)
+    component = fixture.componentInstance
+    fixture.detectChanges()
+  })
 
-    it('should create', () => {
-        expect(component).toBeTruthy();
-    });
-});
+  it('should create', () => {
+    expect(component).toBeTruthy()
+  })
+})

--- a/src/app/layout/components/header/header.component.spec.ts
+++ b/src/app/layout/components/header/header.component.spec.ts
@@ -1,25 +1,32 @@
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { async, ComponentFixture, TestBed } from '@angular/core/testing'
+import { RouterTestingModule } from '@angular/router/testing'
+import { TranslateModule } from '@ngx-translate/core'
 
-import { HeaderComponent } from './header.component';
+import { HeaderComponent } from './header.component'
+import { LayoutModule } from '../../layout.module'
 
 describe('HeaderComponent', () => {
-  let component: HeaderComponent;
-  let fixture: ComponentFixture<HeaderComponent>;
+  let component: HeaderComponent
+  let fixture: ComponentFixture<HeaderComponent>
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      declarations: [ HeaderComponent ]
+      imports: [
+        LayoutModule,
+        RouterTestingModule,
+        TranslateModule.forRoot(),
+      ],
     })
-    .compileComponents();
-  }));
+    .compileComponents()
+  }))
 
   beforeEach(() => {
-    fixture = TestBed.createComponent(HeaderComponent);
-    component = fixture.componentInstance;
-    fixture.detectChanges();
-  });
+    fixture = TestBed.createComponent(HeaderComponent)
+    component = fixture.componentInstance
+    fixture.detectChanges()
+  })
 
   it('should create', () => {
-    expect(component).toBeTruthy();
-  });
-});
+    expect(component).toBeTruthy()
+  })
+})

--- a/src/app/layout/components/sidebar/sidebar.component.spec.ts
+++ b/src/app/layout/components/sidebar/sidebar.component.spec.ts
@@ -1,25 +1,32 @@
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { async, ComponentFixture, TestBed } from '@angular/core/testing'
+import { RouterTestingModule } from '@angular/router/testing'
+import { TranslateModule } from '@ngx-translate/core'
 
-import { SidebarComponent } from './sidebar.component';
+import { SidebarComponent } from './sidebar.component'
+import { LayoutModule } from '../../layout.module'
 
 describe('SidebarComponent', () => {
-  let component: SidebarComponent;
-  let fixture: ComponentFixture<SidebarComponent>;
+  let component: SidebarComponent
+  let fixture: ComponentFixture<SidebarComponent>
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      declarations: [ SidebarComponent ]
+      imports: [
+        LayoutModule,
+        RouterTestingModule,
+        TranslateModule.forRoot(),
+      ],
     })
-    .compileComponents();
-  }));
+    .compileComponents()
+  }))
 
   beforeEach(() => {
-    fixture = TestBed.createComponent(SidebarComponent);
-    component = fixture.componentInstance;
-    fixture.detectChanges();
-  });
+    fixture = TestBed.createComponent(SidebarComponent)
+    component = fixture.componentInstance
+    fixture.detectChanges()
+  })
 
   it('should create', () => {
-    expect(component).toBeTruthy();
-  });
-});
+    expect(component).toBeTruthy()
+  })
+})

--- a/src/app/layout/dashboard/dashboard.component.spec.ts
+++ b/src/app/layout/dashboard/dashboard.component.spec.ts
@@ -1,25 +1,32 @@
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { async, ComponentFixture, TestBed } from '@angular/core/testing'
+import { RouterTestingModule } from '@angular/router/testing'
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations'
 
-import { DashboardComponent } from './dashboard.component';
+import { DashboardComponent } from './dashboard.component'
+import { DashboardModule } from './dashboard.module'
 
 describe('DashboardComponent', () => {
-  let component: DashboardComponent;
-  let fixture: ComponentFixture<DashboardComponent>;
+  let component: DashboardComponent
+  let fixture: ComponentFixture<DashboardComponent>
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      declarations: [ DashboardComponent ]
+      imports: [
+        DashboardModule,
+        RouterTestingModule,
+        BrowserAnimationsModule,
+       ]
     })
-    .compileComponents();
-  }));
+    .compileComponents()
+  }))
 
   beforeEach(() => {
-    fixture = TestBed.createComponent(DashboardComponent);
-    component = fixture.componentInstance;
-    fixture.detectChanges();
-  });
+    fixture = TestBed.createComponent(DashboardComponent)
+    component = fixture.componentInstance
+    fixture.detectChanges()
+  })
 
   it('should create', () => {
-    expect(component).toBeTruthy();
-  });
-});
+    expect(component).toBeTruthy()
+  })
+})

--- a/src/app/layout/form/form.component.spec.ts
+++ b/src/app/layout/form/form.component.spec.ts
@@ -1,26 +1,33 @@
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { async, ComponentFixture, TestBed } from '@angular/core/testing'
+import { RouterTestingModule } from '@angular/router/testing'
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations'
 
-import { FormComponent } from './form.component';
+import { FormComponent } from './form.component'
+import { FormModule } from './form.module'
 
 describe('FormComponent', () => {
-    let component: FormComponent;
-    let fixture: ComponentFixture<FormComponent>;
+  let component: FormComponent
+  let fixture: ComponentFixture<FormComponent>
 
-    beforeEach(
-        async(() => {
-            TestBed.configureTestingModule({
-                declarations: [FormComponent]
-            }).compileComponents();
-        })
-    );
+  beforeEach(
+    async(() => {
+      TestBed.configureTestingModule({
+        imports: [
+          FormModule,
+          BrowserAnimationsModule,
+          RouterTestingModule,
+         ],
+      }).compileComponents()
+    })
+  )
 
-    beforeEach(() => {
-        fixture = TestBed.createComponent(FormComponent);
-        component = fixture.componentInstance;
-        fixture.detectChanges();
-    });
+  beforeEach(() => {
+    fixture = TestBed.createComponent(FormComponent)
+    component = fixture.componentInstance
+    fixture.detectChanges()
+  })
 
-    it('should create', () => {
-        expect(component).toBeTruthy();
-    });
-});
+  it('should create', () => {
+    expect(component).toBeTruthy()
+  })
+})

--- a/src/app/layout/grid/grid.component.spec.ts
+++ b/src/app/layout/grid/grid.component.spec.ts
@@ -1,25 +1,32 @@
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { async, ComponentFixture, TestBed } from '@angular/core/testing'
+import { RouterTestingModule } from '@angular/router/testing'
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations'
 
-import { GridComponent } from './grid.component';
+import { GridComponent } from './grid.component'
+import { GridModule } from './grid.module'
 
 describe('GridComponent', () => {
-  let component: GridComponent;
-  let fixture: ComponentFixture<GridComponent>;
+  let component: GridComponent
+  let fixture: ComponentFixture<GridComponent>
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      declarations: [ GridComponent ]
+      imports: [
+        GridModule,
+        RouterTestingModule,
+        BrowserAnimationsModule,
+      ],
     })
-    .compileComponents();
-  }));
+    .compileComponents()
+  }))
 
   beforeEach(() => {
-    fixture = TestBed.createComponent(GridComponent);
-    component = fixture.componentInstance;
-    fixture.detectChanges();
-  });
+    fixture = TestBed.createComponent(GridComponent)
+    component = fixture.componentInstance
+    fixture.detectChanges()
+  })
 
   it('should create', () => {
-    expect(component).toBeTruthy();
-  });
-});
+    expect(component).toBeTruthy()
+  })
+})

--- a/src/app/layout/layout-routing.module.ts
+++ b/src/app/layout/layout-routing.module.ts
@@ -7,7 +7,7 @@ const routes: Routes = [
         path: '',
         component: LayoutComponent,
         children: [
-            { path: '', redirectTo: 'dashboard' },
+            { path: '', redirectTo: 'dashboard', pathMatch: 'prefix' },
             { path: 'dashboard', loadChildren: './dashboard/dashboard.module#DashboardModule' },
             { path: 'charts', loadChildren: './charts/charts.module#ChartsModule' },
             { path: 'tables', loadChildren: './tables/tables.module#TablesModule' },

--- a/src/app/layout/layout.component.spec.ts
+++ b/src/app/layout/layout.component.spec.ts
@@ -1,26 +1,33 @@
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { async, ComponentFixture, TestBed } from '@angular/core/testing'
+import { RouterTestingModule } from '@angular/router/testing'
+import { TranslateModule } from '@ngx-translate/core'
 
-import { LayoutComponent } from './layout.component';
+import { LayoutComponent } from './layout.component'
+import { LayoutModule } from './layout.module'
 
 describe('LayoutComponent', () => {
-    let component: LayoutComponent;
-    let fixture: ComponentFixture<LayoutComponent>;
+  let component: LayoutComponent
+  let fixture: ComponentFixture<LayoutComponent>
 
-    beforeEach(
-        async(() => {
-            TestBed.configureTestingModule({
-                declarations: [LayoutComponent]
-            }).compileComponents();
-        })
-    );
+  beforeEach(
+    async(() => {
+      TestBed.configureTestingModule({
+        imports: [
+          LayoutModule,
+          RouterTestingModule,
+          TranslateModule.forRoot(),
+        ]
+      }).compileComponents()
+    })
+  )
 
-    beforeEach(() => {
-        fixture = TestBed.createComponent(LayoutComponent);
-        component = fixture.componentInstance;
-        fixture.detectChanges();
-    });
+  beforeEach(() => {
+    fixture = TestBed.createComponent(LayoutComponent)
+    component = fixture.componentInstance
+    fixture.detectChanges()
+  })
 
-    it('should create', () => {
-        expect(component).toBeTruthy();
-    });
-});
+  it('should create', () => {
+    expect(component).toBeTruthy()
+  })
+})

--- a/src/app/layout/tables/tables.component.spec.ts
+++ b/src/app/layout/tables/tables.component.spec.ts
@@ -1,25 +1,20 @@
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { async, TestBed } from '@angular/core/testing'
+import { RouterTestingModule } from '@angular/router/testing'
 
-import { TablesComponent } from './tables.component';
+import { TablesComponent } from './tables.component'
+import { TablesModule } from './tables.module'
 
 describe('TablesComponent', () => {
-  let component: TablesComponent;
-  let fixture: ComponentFixture<TablesComponent>;
-
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      declarations: [ TablesComponent ]
+      imports: [ TablesModule, RouterTestingModule ],
     })
-    .compileComponents();
-  }));
-
-  beforeEach(() => {
-    fixture = TestBed.createComponent(TablesComponent);
-    component = fixture.componentInstance;
-    fixture.detectChanges();
-  });
+    .compileComponents()
+  }))
 
   it('should create', () => {
-    expect(component).toBeTruthy();
-  });
-});
+    const fixture = TestBed.createComponent(TablesComponent)
+    const component = fixture.componentInstance
+    expect(component).toBeTruthy()
+  })
+})

--- a/src/app/login/login.component.spec.ts
+++ b/src/app/login/login.component.spec.ts
@@ -1,25 +1,32 @@
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { async, ComponentFixture, TestBed } from '@angular/core/testing'
+import { RouterTestingModule } from '@angular/router/testing'
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations'
 
-import { LoginComponent } from './login.component';
+import { LoginComponent } from './login.component'
+import { LoginModule } from './login.module'
 
 describe('LoginComponent', () => {
-  let component: LoginComponent;
-  let fixture: ComponentFixture<LoginComponent>;
+  let component: LoginComponent
+  let fixture: ComponentFixture<LoginComponent>
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      declarations: [ LoginComponent ]
+      imports: [
+        LoginModule,
+        RouterTestingModule,
+        BrowserAnimationsModule,
+      ],
     })
-    .compileComponents();
-  }));
+    .compileComponents()
+  }))
 
   beforeEach(() => {
-    fixture = TestBed.createComponent(LoginComponent);
-    component = fixture.componentInstance;
-    fixture.detectChanges();
-  });
+    fixture = TestBed.createComponent(LoginComponent)
+    component = fixture.componentInstance
+    fixture.detectChanges()
+  })
 
   it('should create', () => {
-    expect(component).toBeTruthy();
-  });
-});
+    expect(component).toBeTruthy()
+  })
+})

--- a/src/app/shared/modules/page-header/page-header.component.spec.ts
+++ b/src/app/shared/modules/page-header/page-header.component.spec.ts
@@ -1,25 +1,27 @@
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { async, ComponentFixture, TestBed } from '@angular/core/testing'
+import { RouterTestingModule } from '@angular/router/testing'
 
-import { PageHeaderComponent } from './page-header.component';
+import { PageHeaderComponent } from './page-header.component'
+import { PageHeaderModule } from './page-header.module'
 
 describe('PageHeaderComponent', () => {
-  let component: PageHeaderComponent;
-  let fixture: ComponentFixture<PageHeaderComponent>;
+  let component: PageHeaderComponent
+  let fixture: ComponentFixture<PageHeaderComponent>
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      declarations: [ PageHeaderComponent ]
+      imports: [PageHeaderModule, RouterTestingModule],
     })
-    .compileComponents();
-  }));
+    .compileComponents()
+  }))
 
   beforeEach(() => {
-    fixture = TestBed.createComponent(PageHeaderComponent);
-    component = fixture.componentInstance;
-    fixture.detectChanges();
-  });
+    fixture = TestBed.createComponent(PageHeaderComponent)
+    component = fixture.componentInstance
+    fixture.detectChanges()
+  })
 
   it('should create', () => {
-    expect(component).toBeTruthy();
-  });
-});
+    expect(component).toBeTruthy()
+  })
+})

--- a/src/app/signup/signup.component.spec.ts
+++ b/src/app/signup/signup.component.spec.ts
@@ -1,25 +1,32 @@
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { async, ComponentFixture, TestBed } from '@angular/core/testing'
+import { RouterTestingModule } from '@angular/router/testing'
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations'
 
-import { SignupComponent } from './signup.component';
+import { SignupComponent } from './signup.component'
+import { SignupModule } from './signup.module'
 
 describe('SignupComponent', () => {
-  let component: SignupComponent;
-  let fixture: ComponentFixture<SignupComponent>;
+  let component: SignupComponent
+  let fixture: ComponentFixture<SignupComponent>
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      declarations: [ SignupComponent ]
+      imports: [
+        SignupModule,
+        RouterTestingModule,
+        BrowserAnimationsModule,
+      ],
     })
-    .compileComponents();
-  }));
+    .compileComponents()
+  }))
 
   beforeEach(() => {
-    fixture = TestBed.createComponent(SignupComponent);
-    component = fixture.componentInstance;
-    fixture.detectChanges();
-  });
+    fixture = TestBed.createComponent(SignupComponent)
+    component = fixture.componentInstance
+    fixture.detectChanges()
+  })
 
   it('should create', () => {
-    expect(component).toBeTruthy();
-  });
-});
+    expect(component).toBeTruthy()
+  })
+})


### PR DESCRIPTION
I downloaded this repo, ran `npm install` and `npm test`, and had 16 test failures.

Think this is probably same issue as described here: https://github.com/start-angular/SB-Admin-BS4-Angular-6/issues/180

I fixed the tests in order to be able to add tests to my project and actually use `npm test`, so thought I would open a PR.

The test failures seemed to arise because the "Testing Module" was declaring the component, but not importing other things used by it (in the corresponding module is was actually declared in, outside of the test). So in most cases I fixed this by importing the module in which the component was declared (and usually `RouterTestingModule`, and sometimes `BrowserAnimationsModule` and `TranslateModule`)